### PR TITLE
Fixed channeling bar not showing due to debug output error, made frames clickthrough unless unlocked

### DIFF
--- a/oCB/casting.lua
+++ b/oCB/casting.lua
@@ -214,7 +214,7 @@ end
 
 function oCB:SpellChannelStart(d)
 	self:Debug("SpellChannelStart - Starting channel")
-	self:Debug("ChannelInfo - "..oCBName or arg2.." - "..(oCBRank or "no rank").." - "..(oCBIcon or ""))
+	self:Debug("ChannelInfo - "..(oCBName or arg2).." - "..(oCBRank or "no rank").." - "..(oCBIcon or ""))
 	d = d / 1000
 	local c = self.db.profile.Colors.Channel
 	

--- a/oCB/core.lua
+++ b/oCB/core.lua
@@ -186,6 +186,10 @@ function oCB:ShowTest()
 	if PlayerClass == "HUNTER" then
 		self:MIRROR_TIMER_START("FEIGNDEATH", 0, 10, 1, 0, BS["Feign Death"])
 	end
+
+	for type, frame in pairs(self.frames) do
+		frame:EnableMouse(true)
+	end
 end
 
 function oCB:HideTest()
@@ -194,6 +198,10 @@ function oCB:HideTest()
 	self:MIRROR_TIMER_STOP("BREATH")
 	if PlayerClass == "HUNTER" then
 		self:MIRROR_TIMER_STOP("FEIGNDEATH")
+	end
+
+	for type, frame in pairs(self.frames) do
+		frame:EnableMouse(false)
 	end
 end
 

--- a/oCB/frame.lua
+++ b/oCB/frame.lua
@@ -9,7 +9,7 @@ function oCB:CreateFramework(b, n, s)
 		self.frames[b]:SetScript("OnUpdate", self.OnCasting)
 	end
 	self.frames[b]:SetMovable(true)
-	self.frames[b]:EnableMouse(true)
+	self.frames[b]:EnableMouse(false)
 	self.frames[b]:RegisterForDrag("LeftButton")
 	self.frames[b]:SetScript("OnDragStart", function() if not self.db.profile.lock then this:StartMoving() end end)
 	self.frames[b]:SetScript("OnDragStop", function() this:StopMovingOrSizing() self:savePosition() end)


### PR DESCRIPTION
This should prevent the error causing the channeling bar to not be shown when the spell name cannot be detected. Such a circumstance typically occurs either after 
- A macro is used from the action bars which has no spell attached to it (i.e. a /target macro), or
- An instant cast ability is used

It does NOT fix channeling cast information (spell name) not being shown when the aforementioned conditions are experienced.

Secondly, the castbars are now click through when the frames are locked. This allows the camera to be adjusted if the mouse was over the castbar, and also enables targeting through the bars. Unlocking the frames allows them to be clicked and dragged.
